### PR TITLE
Add simulation init features to inferable rams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 
 ## [Unreleased]
 
+- Switch default implementation from ALTERA to XILINX
+- Add simulation init options to inferable rams (none, 0, random, deadbeef)
+
 ### Added
 
 ### Fixed

--- a/rtl/SyncSpRam.sv
+++ b/rtl/SyncSpRam.sv
@@ -25,7 +25,9 @@ module SyncSpRam
   parameter ADDR_WIDTH = 10,
   parameter DATA_DEPTH = 1024, // usually 2**ADDR_WIDTH, but can be lower
   parameter DATA_WIDTH = 32,
-  parameter OUT_REGS   = 0
+  parameter OUT_REGS   = 0,
+  parameter SIM_INIT   = 0     // for simulation only, will not be synthesized
+                               // 0: no init, 1: zero init, 2: random init
 ) (
   input  logic                    Clk_CI,
   input  logic                    Rst_RBI,
@@ -50,6 +52,16 @@ module SyncSpRam
 
   always_ff @(posedge Clk_CI)
   begin
+    //pragma translate_off
+    automatic logic [DATA_WIDTH-1:0] val;
+    if(Rst_RBI == 1'b0 && SIM_INIT>0) begin
+      for(int k=0; k<DATA_DEPTH;k++) begin
+        if(SIM_INIT==1) val = '0;
+        else if(SIM_INIT==2) void'(randomize(val));
+        Mem_DP[k] = val;
+      end
+    end else 
+    //pragma translate_on    
     if (CSel_SI) begin
       if (WrEn_SI) begin
         Mem_DP[Addr_DI] <= WrData_DI;

--- a/rtl/SyncSpRamBeNx64.sv
+++ b/rtl/SyncSpRamBeNx64.sv
@@ -21,15 +21,17 @@
  * - Michael Schaffner  <schaffer@iis.ee.ethz.ch>
  */
 
-`ifndef FPGA_TARGET_XILINX
-  `define FPGA_TARGET_ALTERA
+`ifndef FPGA_TARGET_ALTERA
+  `define FPGA_TARGET_XILINX
 `endif
 
 module SyncSpRamBeNx64
 #(
   parameter ADDR_WIDTH = 10,
   parameter DATA_DEPTH = 1024, // usually 2**ADDR_WIDTH, but can be lower
-  parameter OUT_REGS   = 0     // set to 1 to enable outregs
+  parameter OUT_REGS   = 0,    // set to 1 to enable outregs
+  parameter SIM_INIT   = 0     // for simulation only, will not be synthesized
+                               // 0: no init, 1: zero init, 2: random init, 3: deadbeef init
 ) (
   input  logic                  Clk_CI,
   input  logic                  Rst_RBI,
@@ -59,6 +61,17 @@ module SyncSpRamBeNx64
     logic [DATA_BYTES*8-1:0] Mem_DP[DATA_DEPTH-1:0];
 
     always_ff @(posedge Clk_CI) begin
+      //pragma translate_off
+      automatic logic [63:0] val;
+      if(Rst_RBI == 1'b0 && SIM_INIT>0) begin
+        for(int k=0; k<DATA_DEPTH;k++) begin
+          if(SIM_INIT==1) val = '0;
+          else if(SIM_INIT==2) void'(randomize(val));
+          else val = 64'hdeadbeefdeadbeef;
+          Mem_DP[k] = val;
+        end
+      end else 
+      //pragma translate_on
       if(CSel_SI) begin
         if(WrEn_SI) begin
           if(BEn_SI[0]) Mem_DP[Addr_DI][7:0]   <= WrData_DI[7:0];
@@ -83,6 +96,17 @@ module SyncSpRamBeNx64
     logic [DATA_BYTES-1:0][7:0] Mem_DP[0:DATA_DEPTH-1];
 
     always_ff @(posedge Clk_CI) begin
+      //pragma translate_off
+      automatic logic [63:0] val;
+      if(Rst_RBI == 1'b0 && SIM_INIT>0) begin
+        for(int k=0; k<DATA_DEPTH;k++) begin
+          if(SIM_INIT==1) val = '0;
+          else if(SIM_INIT==2) void'(randomize(val));
+          else val = 64'hdeadbeefdeadbeef;
+          Mem_DP[k] = val;
+        end
+      end else 
+      //pragma translate_on
       if(CSel_SI) begin
         if(WrEn_SI) begin // needs to be static, otherwise Altera wont infer it
           if(BEn_SI[0]) Mem_DP[Addr_DI][0] <= WrData_DI[7:0];

--- a/rtl/SyncTpRam.sv
+++ b/rtl/SyncTpRam.sv
@@ -28,7 +28,9 @@ module SyncTpRam
   parameter ADDR_WIDTH = 10,
   parameter DATA_DEPTH = 1024, // usually 2**ADDR_WIDTH, but can be lower
   parameter DATA_WIDTH = 32,
-  parameter OUT_REGS   = 0
+  parameter OUT_REGS   = 0,
+  parameter SIM_INIT   = 0     // for simulation only, will not be synthesized
+                               // 0: no init, 1: zero init, 2: random init
 ) (
   input  logic                    Clk_CI,
   input  logic                    Rst_RBI,
@@ -54,12 +56,25 @@ module SyncTpRam
 
   always_ff @(posedge Clk_CI)
   begin
+    //pragma translate_off
+    automatic logic [DATA_WIDTH-1:0] val;
+    if(Rst_RBI == 1'b0 && SIM_INIT>0) begin
+      for(int k=0; k<DATA_DEPTH;k++) begin
+        if(SIM_INIT==1) val = '0;
+        else if(SIM_INIT==2) void'(randomize(val));
+        Mem_DP[k] = val;
+      end
+    end else begin
+    //pragma translate_on    
     if (RdEn_SI) begin
       RdData_DN <= Mem_DP[RdAddr_DI];
     end
     if (WrEn_SI) begin
       Mem_DP[WrAddr_DI] <= WrData_DI;
     end
+    //pragma translate_off
+    end
+    //pragma translate_on  
   end
 
   ////////////////////////////


### PR DESCRIPTION
I ran a synthesis regression on Vivado and all implementations synthesize correctly.